### PR TITLE
Make Docker container port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:17.0.5_8-jre-jammy
+ENV PORT 8080
 
 RUN set -eux; \
 	apt-get update; \
@@ -6,6 +7,6 @@ RUN set -eux; \
 
 ADD build/libs/structurizr-lite.war /usr/local/structurizr-lite.war
 
-EXPOSE 8080
+EXPOSE ${PORT}
 
-CMD ["java", "-Djdk.util.jar.enableMultiRelease=false", "-jar", "/usr/local/structurizr-lite.war"]
+CMD ["java", "-Djdk.util.jar.enableMultiRelease=false", "-Dserver.port=${PORT}", "-jar", "/usr/local/structurizr-lite.war"]


### PR DESCRIPTION
Some cloud providers like Heroku assign random ports to Docker containers on startup via a `PORT` environment variable.

This change allows users (and cloud providers) to more easily configure which port Structurizr runs on without...

* copy / paste / modifying the original `CMD` in the Dockerfile
* needing to control the `--publish` Docker CLI parameter

To test, we can use `docker run` with an `--env` parameter that sets the port to something other than 8080.

```bash
docker build --tag localhost/structurizr-lite .
docker run --rm -it \
    --env PORT=8081 \
    --publish "8081:8081" \
    localhost/structurizr-lite:latest

# in another terminal:
curl --verbose http://localhost:8081/
```

This should output:

```plaintext
*   Trying 127.0.0.1:8081...
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 
< Referrer-Policy: strict-origin-when-cross-origin
< X-Frame-Options: deny
< Location: http://localhost:8081/workspace/diagrams
< Content-Language: en-US
< Content-Length: 0
< Date: Tue, 15 Aug 2023 10:32:48 GMT
< 
* Connection #0 to host localhost left intact
```