### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.1_12-jre-jammy
+FROM eclipse-temurin:21.0.2_13-jre-jammy
 ENV PORT 8080
 
 RUN set -eux; \


### PR DESCRIPTION
Update base image to use jre 21.0.2_13 to mitigate high severity vulnerability in previous java version. CVE-2024-20952
CVE-2024-20918