### PR TITLE
Show real error message when workspace has bad format

### DIFF
--- a/src/main/java/com/structurizr/lite/component/workspace/FileSystemWorkspaceComponentImpl.java
+++ b/src/main/java/com/structurizr/lite/component/workspace/FileSystemWorkspaceComponentImpl.java
@@ -1,8 +1,8 @@
 package com.structurizr.lite.component.workspace;
 
 import com.structurizr.Workspace;
-import com.structurizr.api.WorkspaceMetadata;
 import com.structurizr.dsl.StructurizrDslParser;
+import com.structurizr.dsl.StructurizrDslParserException;
 import com.structurizr.lite.Configuration;
 import com.structurizr.lite.component.search.SearchComponent;
 import com.structurizr.lite.util.DateUtils;
@@ -137,6 +137,8 @@ class FileSystemWorkspaceComponentImpl implements WorkspaceComponent {
                 workspace = WorkspaceUtils.loadWorkspaceFromJson(jsonFile);
                 workspace.setId(workspaceId);
                 error = null;
+            } catch (StructurizrDslParserException e) {
+                throw new WorkspaceParsingException(e.getMessage());
             } catch (Exception e) {
                 workspace = null;
                 error = filename + ".json: " + e.getMessage();
@@ -178,6 +180,8 @@ class FileSystemWorkspaceComponentImpl implements WorkspaceComponent {
             }
 
             error = null;
+        } catch (StructurizrDslParserException e) {
+            throw new WorkspaceParsingException(e.getMessage());
         } catch (Exception e) {
             workspace = null;
             error = filename + ".dsl: " + e.getMessage();

--- a/src/main/java/com/structurizr/lite/component/workspace/WorkspaceParsingException.java
+++ b/src/main/java/com/structurizr/lite/component/workspace/WorkspaceParsingException.java
@@ -1,0 +1,12 @@
+package com.structurizr.lite.component.workspace;
+
+public class WorkspaceParsingException extends RuntimeException {
+
+    public WorkspaceParsingException(String message) {
+        super(message);
+    }
+
+    public WorkspaceParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Hello. I often start structurizr-lite on my computer to work with structurizr dsl, I make some change, refresh page in browser, look at result and continue work.

But if I make error, I get strange message in browser "No workspace.dsl or workspace.json file was found". If I want to see real error I should look at logs. So I change this behaviour and now I can see real error not only in terminal, but in browser too.

Before:
<img width="832" alt="Снимок экрана 2024-07-01 в 20 50 14" src="https://github.com/structurizr/lite/assets/6325570/836242d5-2aa7-4180-80d1-785cf42aad78">

After:
<img width="946" alt="Снимок экрана 2024-07-01 в 21 07 16" src="https://github.com/structurizr/lite/assets/6325570/90b87976-d769-4edb-81f6-009ad2d2feea">
