### PR TITLE
Drop obsolete params for Spring < 3.0.5 from Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ EXPOSE ${PORT}
 
 HEALTHCHECK CMD curl --fail http://localhost:${PORT}/health || exit 1
 
-CMD ["java", "-Djdk.util.jar.enableMultiRelease=false", "-Dserver.port=${PORT}", "-jar", "/usr/local/structurizr-lite.war"]
+CMD ["java", "-Dserver.port=${PORT}", "-jar", "/usr/local/structurizr-lite.war"]

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ cd structurizr-lite
 And to run Structurizr Lite (this has only been tested with Java 17):
 
 ```
-java -Djdk.util.jar.enableMultiRelease=false -jar build/libs/structurizr-lite.war /path/to/workspace
+java -jar build/libs/structurizr-lite.war /path/to/workspace
 ```
 
 - Replace `/path/to/workspace` with the path to the folder where your `workspace.dsl` file is.
-- See https://github.com/spring-projects/spring-boot/issues/33633 for details of why `-Djdk.util.jar.enableMultiRelease=false` is required.


### PR DESCRIPTION
I got curious with `-Djdk.util.jar.enableMultiRelease=false` and read through the linked thread - looks like the issue was fixed a good while ago.
Indeed, a test on my end showed that the property was no longer required.

I raised [another PR]() in the pages-repo for the documentation changes there.