### PR TITLE
Add support for CSS and/or JS customization.

### DIFF
--- a/src/main/java/com/structurizr/lite/web/AbstractController.java
+++ b/src/main/java/com/structurizr/lite/web/AbstractController.java
@@ -4,13 +4,18 @@ import com.structurizr.lite.Configuration;
 import com.structurizr.lite.component.workspace.WorkspaceComponent;
 import com.structurizr.lite.util.RandomGuidGenerator;
 import com.structurizr.lite.util.Version;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Base64;
 import java.util.TimeZone;
 
@@ -20,6 +25,10 @@ public abstract class AbstractController {
     private static final String REFERER_POLICY_HEADER = "Referrer-Policy";
     private static final String REFERER_POLICY_VALUE = "strict-origin-when-cross-origin";
     private static final String SCRIPT_NONCE_ATTRIBUTE = "scriptNonce";
+    
+    private static final Log log = LogFactory.getLog(AbstractController.class);
+    private static final String STRUCTURIZR_CSS_FILENAME = "structurizr.css";
+    private static final String STRUCTURIZR_JS_FILENAME = "structurizr.js";
 
     protected WorkspaceComponent workspaceComponent;
 
@@ -48,6 +57,24 @@ public abstract class AbstractController {
         model.addAttribute("showHeader", showHeaderAndFooter);
         model.addAttribute("showFooter", showHeaderAndFooter);
         model.addAttribute("version", new Version());
+        
+        File cssFile = new File(Configuration.getInstance().getDataDirectory(), STRUCTURIZR_CSS_FILENAME);
+        if (cssFile.exists()) {
+            try {
+                model.addAttribute("css", Files.readString(cssFile.toPath()));
+            } catch (IOException ioe) {
+                log.warn(ioe);
+            }
+        }
+
+        File jsFile = new File(Configuration.getInstance().getDataDirectory(), STRUCTURIZR_JS_FILENAME);
+        if (jsFile.exists()) {
+            try {
+                model.addAttribute("js", Files.readString(jsFile.toPath()));
+            } catch (IOException ioe) {
+                log.warn(ioe);
+            }
+        }
 
         if (pageTitle == null || pageTitle.trim().length() == 0) {
             model.addAttribute("pageTitle", "Structurizr");

--- a/src/main/webapp/WEB-INF/fragments/prelude.jspf
+++ b/src/main/webapp/WEB-INF/fragments/prelude.jspf
@@ -18,6 +18,13 @@
     <link href="${structurizrConfiguration.cdnUrl}/css/bootstrap-3.3.7.min.css" rel="stylesheet" media="screen" />
     <link href="${structurizrConfiguration.cdnUrl}/css/bootstrap-theme-3.3.7.min.css" rel="stylesheet" media="screen" />
     <link href="${structurizrConfiguration.cdnUrl}/css/structurizr.css" rel="stylesheet" media="screen" />
+
+    <c:if test="${not empty css}">
+    <style>
+    ${css}
+    </style>
+    </c:if>
+
     <c:if test="${embed eq true}">
     <link href="${structurizrConfiguration.cdnUrl}/css/structurizr-embed.css" rel="stylesheet" media="screen" />
     </c:if>
@@ -29,6 +36,16 @@
     <script type="text/javascript" src="${structurizrConfiguration.cdnUrl}/js/structurizr${structurizrConfiguration.versionSuffix}.js"></script>
     <script type="text/javascript" src="${structurizrConfiguration.cdnUrl}/js/structurizr-ui${structurizrConfiguration.versionSuffix}.js"></script>
     <script type="text/javascript" src="${structurizrConfiguration.cdnUrl}/js/structurizr-util${structurizrConfiguration.versionSuffix}.js"></script>
+
+    <c:if test="${not empty js}">
+    <script nonce="${scriptNonce}">
+        try {
+    ${js}
+        } catch (err) {
+            console.error(err);
+        }
+    </script>
+    </c:if>
 </head>
 
 <script nonce="${scriptNonce}">


### PR DESCRIPTION
This commit copies code from the [customization](https://docs.structurizr.com/onpremises/customisation)-related code from the on-premise version of structurizr, so that the lite version of structurizr can support the same feature - placing a correctly named CSS and/or JS file in the data directory will allow for customization of the rendered pages.