### PR TITLE
Add Docker image with export infrastructure.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.6_7-jre-noble
+FROM eclipse-temurin:21.0.6_7-jre-noble AS structurizr-lite
 ENV PORT=8080
 
 RUN set -eux; \
@@ -12,3 +12,28 @@ EXPOSE ${PORT}
 HEALTHCHECK CMD curl --fail http://localhost:${PORT}/health || exit 1
 
 CMD ["java", "-Dserver.port=${PORT}", "-jar", "/usr/local/structurizr-lite.war"]
+
+FROM structurizr-lite AS structurizr-export
+
+ENV STRUCTURIZR_EXPORT=/opt/structurizr-export
+ENV STRUCTURIZR_WORKSPACE_PATH=/workspace
+
+RUN set -eux; \
+	apt-get install -y --no-install-recommends git nodejs npm; \
+        git clone https://github.com/structurizr/puppeteer.git $STRUCTURIZR_EXPORT; \
+        sed -i $STRUCTURIZR_EXPORT/export-diagrams.js -e 's@headless: HEADLESS@headless: HEADLESS, args: [ "--no-sandbox" ]@'; \
+        sed -i $STRUCTURIZR_EXPORT/export-documentation.js -e 's@headless: HEADLESS@headless: HEADLESS, args: [ "--no-sandbox" ]@'; \
+	cd $STRUCTURIZR_EXPORT; \
+        npm install puppeteer; \
+	npx puppeteer browsers install --install-deps chrome-headless-shell@stable; \
+	mkdir $STRUCTURIZR_WORKSPACE_PATH; \
+        apt-get remove -y --purge git npm; \
+        apt-get autoremove -y; \
+	rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+COPY --chmod=0775 puppeteer-export-diagrams.sh /usr/local/bin/export-diagrams
+COPY --chmod=0775 puppeteer-export-documentation.sh /usr/local/bin/export-documentation
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/puppeteer-export-diagrams.sh
+++ b/puppeteer-export-diagrams.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# export <output-directory> [[format] ...]
+
+cleanup() {
+    kill %1
+    wait
+}
+
+export STRUCTURIZR_WORKSPACE_FILENAME=$1
+shift
+OUTPUT_DIR="${STRUCTURIZR_WORKSPACE_PATH}/${1}"
+shift
+
+java -Dserver.port=${PORT} -jar /usr/local/structurizr-lite.war / &
+(until printf "" 2>>/dev/null >>/dev/tcp/localhost/$PORT; do sleep 1; done) > /dev/null 2>&1
+
+trap cleanup EXIT
+trap cleanup INT
+trap cleanup TERM
+
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+
+for FORMAT in $@; do
+    echo exporting $STRUCTURIZR_WORKSPACE_FILENAME diagrams to $FORMAT in $OUTPUT_DIR
+    for FILE in $(node $STRUCTURIZR_EXPORT/export-diagrams.js http://localhost:$PORT $FORMAT | grep "^ - .*\\.$FORMAT" | sed "s/ - //"); do
+        OUTPUT_FILE="$OUTPUT_DIR/${STRUCTURIZR_WORKSPACE_FILENAME}_${FILE}"
+        mv "$OUTPUT_DIR/$FILE" "$OUTPUT_FILE"
+        echo exported "$OUTPUT_FILE"
+    done
+done

--- a/puppeteer-export-documentation.sh
+++ b/puppeteer-export-documentation.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# export <output-directory> [[format] ...]
+
+cleanup() {
+    kill %1
+    wait
+}
+
+export STRUCTURIZR_WORKSPACE_FILENAME=$1
+shift
+OUTPUT_DIR="${STRUCTURIZR_WORKSPACE_PATH}/${1}"
+shift
+
+java -Dserver.port=${PORT} -jar /usr/local/structurizr-lite.war / &
+(until printf "" 2>>/dev/null >>/dev/tcp/localhost/$PORT; do sleep 1; done) > /dev/null 2>&1
+
+trap cleanup EXIT
+trap cleanup INT
+trap cleanup TERM
+
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+
+echo exporting $STRUCTURIZR_WORKSPACE_FILENAME documentation in $OUTPUT_DIR
+node $STRUCTURIZR_EXPORT/export-documentation.js http://localhost:$PORT $FORMAT


### PR DESCRIPTION
Updates the Dockerfile to add a new structurizr-export on top of the original structurizr-lite image. The image is configured with puppeteer, headless google chrome, the puppeteer structurizr export repository and 2 scripts to do the actual exports.

With this image, one can run

```
docker run --rm -v .:/workspace -it structurizr-export:latest export-diagrams workspace build svg
```

to export the diagrams to svg. There's also an export-documentation script.